### PR TITLE
Fix bitcode for dynamic framework

### DIFF
--- a/create-openssl-framework.sh
+++ b/create-openssl-framework.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 FWNAME=openssl
 FWDIR=frameworks
 
@@ -15,6 +17,28 @@ fi
 
 ALL_SYSTEMS=("iPhone" "AppleTV")
 
+
+function check_bitcode() {
+    local FRAMEWORK=$1
+    local TYPE=$2
+
+    FRAMEWORK_NAME=$(basename $1)
+    FRAMEWORK_NAME=${FRAMEWORK_NAME%.framework}
+
+    if [[ TYPE == "static" ]]; then
+        BITCODE_PATTEN=__bitcode
+    else
+        BITCODE_PATTEN=__LLVM
+    fi
+
+    if otool -arch arm64 -l "${FRAMEWORK}/${FRAMEWORK_NAME}" | grep -q "${BITCODE_PATTEN}"; then
+        echo "INFO: $FRAMEWORK contains Bitcode"
+    else
+        echo "INFO: $FRAMEWORK doesn't contain Bitcode"
+    fi
+}
+
+
 if [ "$1" == "dynamic" ]; then
     DEVELOPER=`xcode-select -print-path`
     FW_EXEC_NAME="${FWNAME}.framework/${FWNAME}"
@@ -25,7 +49,7 @@ if [ "$1" == "dynamic" ]; then
     RX='([A-z]+)([0-9]+(\.[0-9]+)*)-([A-z0-9]+)\.sdk'
 
     cd bin
-	for TARGETDIR in `ls -d *.sdk`; do
+    for TARGETDIR in `ls -d *.sdk`; do
         if [[ $TARGETDIR =~ $RX ]]; then
             PLATFORM="${BASH_REMATCH[1]}"
             SDKVERSION="${BASH_REMATCH[2]}"
@@ -54,7 +78,18 @@ if [ "$1" == "dynamic" ]; then
         ar -x ../lib/libcrypto.a
         ar -x ../lib/libssl.a
         cd ..
-        ld obj/*.o -dylib -lSystem -arch $ARCH $MIN_SDK -syslibroot $SDK -compatibility_version $COMPAT_VERSION -current_version $CURRENT_VERSION -application_extension -o $FWNAME.dylib
+
+        ld obj/*.o \
+            -dylib \
+            -bitcode_bundle \
+            -lSystem \
+            -arch $ARCH \
+            $MIN_SDK \
+            -syslibroot $SDK \
+            -compatibility_version $COMPAT_VERSION \
+            -current_version $CURRENT_VERSION \
+            -application_extension \
+            -o $FWNAME.dylib
         install_name_tool -id $INSTALL_NAME $FWNAME.dylib
 
         cd ..
@@ -64,14 +99,19 @@ if [ "$1" == "dynamic" ]; then
     for SYS in ${ALL_SYSTEMS[@]}; do
         SYSDIR=$FWDIR/$SYS
 
-        # FIXME: skip if no device objects
+        DYLIBS=(bin/${SYS}*/$FWNAME.dylib)
 
-        echo "Creating framework for $SYS"
-        mkdir -p $SYSDIR/$FWNAME.framework/Headers
-        lipo -create bin/${SYS}*/$FWNAME.dylib -output $SYSDIR/$FWNAME.framework/$FWNAME
-        cp -r include/$FWNAME/* $SYSDIR/$FWNAME.framework/Headers/
-        cp -L assets/$SYS/Info.plist $SYSDIR/$FWNAME.framework/Info.plist
-        echo "Created $SYSDIR/$FWNAME.framework"
+        if [[ ${#DYLIBS[@]} -gt 0 && -e ${DYLIBS[0]} ]]; then
+            echo "Creating framework for $SYS"
+            mkdir -p $SYSDIR/$FWNAME.framework/Headers
+            lipo -create ${DYLIBS[@]} -output $SYSDIR/$FWNAME.framework/$FWNAME
+            cp -r include/$FWNAME/* $SYSDIR/$FWNAME.framework/Headers/
+            cp -L assets/$SYS/Info.plist $SYSDIR/$FWNAME.framework/Info.plist
+            echo "Created $SYSDIR/$FWNAME.framework"
+            check_bitcode $SYSDIR/$FWNAME.framework dynamic
+        else
+            echo "Skipped framework for $SYS"
+        fi
     done
 
     rm bin/*/$FWNAME.dylib
@@ -79,21 +119,19 @@ else
     for SYS in ${ALL_SYSTEMS[@]}; do
         SYSDIR=$FWDIR/$SYS
 
-        # FIXME: skip if no device objects
-
-        echo "Creating framework for $SYS"
-        mkdir -p $SYSDIR/$FWNAME.framework/Headers
-        libtool -static -o $SYSDIR/$FWNAME.framework/$FWNAME lib/libcrypto-$SYS.a lib/libssl-$SYS.a
-        cp -r include/$FWNAME/* $SYSDIR/$FWNAME.framework/Headers/
-        cp -L assets/$SYS/Info.plist $SYSDIR/$FWNAME.framework/Info.plist
-        echo "Created $SYSDIR/$FWNAME.framework"
+        if [[ -e lib/libcrypto-$SYS.a && -e lib/libssl-$SYS.a ]]; then
+            echo "Creating framework for $SYS"
+            mkdir -p $SYSDIR/$FWNAME.framework/Headers
+            libtool -static -o $SYSDIR/$FWNAME.framework/$FWNAME lib/libcrypto-$SYS.a lib/libssl-$SYS.a
+            cp -r include/$FWNAME/* $SYSDIR/$FWNAME.framework/Headers/
+            cp -L assets/$SYS/Info.plist $SYSDIR/$FWNAME.framework/Info.plist
+            echo "Created $SYSDIR/$FWNAME.framework"
+            check_bitcode $SYSDIR/$FWNAME.framework static
+        else
+            echo "Skipped framework for $SYS"
+        fi
     done
 fi
 
-check_bitcode=`otool -arch arm64 -l $FWDIR/iPhone/$FWNAME.framework/$FWNAME | grep __bitcode`
-if [ -z "$check_bitcode" ]
-then
-  echo "INFO: $FWNAME.framework doesn't contain Bitcode"
-else
-  echo "INFO: $FWNAME.framework contains Bitcode"
-fi
+
+


### PR DESCRIPTION
These changes embed the bitcode in the resulting framework, and also checks the presence of the `__LLVM` section.